### PR TITLE
Lint full repository

### DIFF
--- a/cinspect/__init__.py
+++ b/cinspect/__init__.py
@@ -1,2 +1,4 @@
 # Copyright (c) Gradient Institute. All rights reserved.
 # Licensed under the Apache 2.0 License.
+
+"""A Scikit-learn inspired inspection module for causal models."""

--- a/cinspect/dependence.py
+++ b/cinspect/dependence.py
@@ -3,13 +3,12 @@
 """Partial dependence and individual conditional expectation functions."""
 
 import numbers
+from typing import Optional, Tuple
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-
-# from typing import Any, List, Tuple, Optional, Literal
 from scipy.stats.mstats import mquantiles
-
 
 # default image type to use for figures TODO delete dependence on this
 IMAGE_TYPE = "png"
@@ -123,23 +122,39 @@ def individual_conditional_expectation(
     return grid_values, pred.T, grid_counts
 
 
-def construct_grid(grid_values, v, auto_threshold=20):
-    """
+def construct_grid(
+    grid_values, v, auto_threshold=20
+) -> Tuple[np.ndarray, Optional[np.ndarray]]:
+    """Construct grid from a set of values.
+
+    Parameters
+    ----------
     grid_values: ["auto"|"unique"|int|array]
     v: np.array
         The set of values for the feature
-    auto_threshold: int
+    auto_threshold: int, optional
         how many unique values must a feature exceed to be treated as
         continuous (applied only if grid_values=="auto").
+
+    Returns
+    -------
+    grid, grid_counts: Tuple[np.ndarray, Optional[np.ndarray]]
+        Constructed grid, and its counts of unique elements.
+        Returns counts iff grid_values=="unique" or ("auto" and n_unique(v)>auto_threshold).
+
+    Raises
+    ------
+    ValueError
+        If grid cannot be constructed with given arguments
     """
     grid_counts = None
     grid = None
 
     if isinstance(grid_values, np.ndarray):
-        return grid_values, None
+        # check grid_values is not an array,
+        # as np.array==str raises a futurewarning
 
-    # need to check grid_values is not an array first as np.array==str raises a
-    # futurewarning
+        return grid_values, None
     else:
         if grid_values == "auto":  # here I also need to check type of column
             if np.issubdtype(v.dtype, np.number):
@@ -176,7 +191,7 @@ def construct_grid(grid_values, v, auto_threshold=20):
             low, high = np.nanmin(v), np.nanmax(v)
             try:
                 grid = np.linspace(low, high, grid_values)
-            except:
+            except Exception:  # TODO: make more specific
                 message = (
                     "Could not create grid: " f"linspace({low}, {high}, {grid_values})"
                 )
@@ -188,6 +203,10 @@ def construct_grid(grid_values, v, auto_threshold=20):
 def plot_partial_dependence_density(
     ax, grid, density, feature_name, categorical, color="black", alpha=0.5
 ):
+    """Plot partial dependency on ax.
+
+    TODO: proper docstring
+    """
     # plot the distribution for of the variable on the second axis
     if categorical:
         x = np.arange(len(grid))
@@ -219,7 +238,10 @@ def plot_partial_dependence_with_uncertainty(
     label=None,
     ci_bounds=(0.025, 0.975),
 ):
-    """
+    """Plot partial dependence plot with uncertainty estimates.
+
+    TODO: proper docstring.
+
     Parameters
     ----------
     grid: np.array

--- a/cinspect/dependence.py
+++ b/cinspect/dependence.py
@@ -6,6 +6,7 @@ import numbers
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+
 # from typing import Any, List, Tuple, Optional, Literal
 from scipy.stats.mstats import mquantiles
 
@@ -28,9 +29,10 @@ def numpy2d_to_dataframe_with_types(X, columns, types):
 
     """
     nxcols, ncols, ntypes = X.shape[1], len(columns), len(types)
-    assert nxcols == ncols == ntypes, \
-        f"with of array, len(columns) and len(types) much match, " \
+    assert nxcols == ncols == ntypes, (
+        f"with of array, len(columns) and len(types) much match, "
         f"got {nxcols},{ncols},{ntypes}"
+    )
     d = {}
     for j, c in enumerate(columns):
         ctype = types[c]
@@ -38,8 +40,9 @@ def numpy2d_to_dataframe_with_types(X, columns, types):
     return pd.DataFrame(d)
 
 
-def individual_conditional_expectation(model, X, feature, grid_values,
-                                       predict_method=None):
+def individual_conditional_expectation(
+    model, X, feature, grid_values, predict_method=None
+):
     """
     Compute the ICE curve for a given point.
 
@@ -77,13 +80,17 @@ def individual_conditional_expectation(model, X, feature, grid_values,
     """
     if predict_method is None:
         if hasattr(model, "predict_proba"):
+
             def predict_method(X):
                 return model.predict_proba(X)[:, 1]
+
         elif hasattr(model, "predict"):
             predict_method = model.predict
         else:
-            m = "model does not support predict_proba or predict and no " \
+            m = (
+                "model does not support predict_proba or predict and no "
                 "alternate method specified."
+            )
             raise ValueError(m)
 
     input_df = False  # track if the predictor is expecting a dataframe
@@ -95,7 +102,8 @@ def individual_conditional_expectation(model, X, feature, grid_values,
 
     if not input_df and not isinstance(feature, numbers.Integral):
         raise ValueError(
-            "Features may only be passed as a string if X is a pd.DataFrame")
+            "Features may only be passed as a string if X is a pd.DataFrame"
+        )
 
     values = X[:, feature]
     grid_values, grid_counts = construct_grid(grid_values, values)
@@ -169,29 +177,23 @@ def construct_grid(grid_values, v, auto_threshold=20):
             try:
                 grid = np.linspace(low, high, grid_values)
             except:
-                message = "Could not create grid: " \
-                    f"linspace({low}, {high}, {grid_values})"
+                message = (
+                    "Could not create grid: " f"linspace({low}, {high}, {grid_values})"
+                )
                 raise ValueError(message)
 
     return grid, grid_counts
 
 
 def plot_partial_dependence_density(
-    ax,
-    grid,
-    density,
-    feature_name,
-    categorical,
-    color="black",
-    alpha=0.5
+    ax, grid, density, feature_name, categorical, color="black", alpha=0.5
 ):
     # plot the distribution for of the variable on the second axis
     if categorical:
         x = np.arange(len(grid))
         ax.bar(x, density, color=color, alpha=alpha)
         ax.set_xticks(x)
-        ax.set_xticklabels(grid, rotation=20,
-                           horizontalalignment="right")
+        ax.set_xticklabels(grid, rotation=20, horizontalalignment="right")
         ax.set_ylabel("counts")
 
     else:
@@ -203,19 +205,19 @@ def plot_partial_dependence_density(
 
 
 def plot_partial_dependence_with_uncertainty(
-        grid,
-        predictions,
-        feature_name,
-        categorical=True,
-        density=None,
-        name="",
-        mode="multiple-pd-lines",
-        ax=None,
-        color="black",
-        color_samples="grey",
-        alpha=None,
-        label=None,
-        ci_bounds=(0.025, 0.975)
+    grid,
+    predictions,
+    feature_name,
+    categorical=True,
+    density=None,
+    name="",
+    mode="multiple-pd-lines",
+    ax=None,
+    color="black",
+    color_samples="grey",
+    alpha=None,
+    label=None,
+    ci_bounds=(0.025, 0.975),
 ):
     """
     Parameters
@@ -244,14 +246,16 @@ def plot_partial_dependence_with_uncertainty(
 
     if ax is not None:
         if density is not None:
-            raise ValueError("Plotting dependence with density requires "
-                             "subplots and cannot be added to existing axis.")
+            raise ValueError(
+                "Plotting dependence with density requires "
+                "subplots and cannot be added to existing axis."
+            )
 
     if ax is None:
         if density is not None:
-            fig, axes = plt.subplots(2, 1, figsize=(6, 5),
-                                     gridspec_kw={'height_ratios': [3, 1]},
-                                     sharex=True)
+            fig, axes = plt.subplots(
+                2, 1, figsize=(6, 5), gridspec_kw={"height_ratios": [3, 1]}, sharex=True
+            )
 
             # plot the distribution for of the variable on the second axis
             plot_partial_dependence_density(
@@ -295,7 +299,7 @@ def plot_partial_dependence_with_uncertainty(
         p_all = np.vstack(predictions)
         mu = p_all.mean(axis=0)
         s = p_all.std(axis=0)
-        ax.fill_between(x, mu-s, mu+s, alpha=0.5)
+        ax.fill_between(x, mu - s, mu + s, alpha=0.5)
         ax.plot(x, mu)
 
     elif mode == "derivative" or mode == "interval":
@@ -318,8 +322,7 @@ def plot_partial_dependence_with_uncertainty(
         ax.legend()
 
     else:
-        valid_modes = ["multiple-pd-lines", "ice-mu-sd", "derivative",
-                       "interval"]
+        valid_modes = ["multiple-pd-lines", "ice-mu-sd", "derivative", "interval"]
         raise ValueError(f"Unknown mode {mode}. Must be one of: {valid_modes}")
 
     return fig

--- a/cinspect/dimension.py
+++ b/cinspect/dimension.py
@@ -26,10 +26,10 @@ def effective_rank(X: Union[np.ndarray, pd.DataFrame]) -> float:
 
 
     """
-    u, s, v = np.linalg.svd(X.T@X)
+    u, s, v = np.linalg.svd(X.T @ X)
     norm_s = np.abs(s).sum()
-    p = s/norm_s
-    H = -(p*np.log(p)).sum()
+    p = s / norm_s
+    H = -(p * np.log(p)).sum()
     erank = np.exp(H)
     return float(erank)
 
@@ -38,7 +38,7 @@ def greedy_feature_selection(
     X: np.ndarray,
     maximise_metric: Callable[[np.ndarray], float],
     initial_col: Optional[int] = None,
-    num_to_select: int = 10
+    num_to_select: int = 10,
 ) -> Tuple[List[int], List[float]]:
     """
     Repeatedly select features to maximise the specified metric.

--- a/cinspect/estimators.py
+++ b/cinspect/estimators.py
@@ -55,8 +55,7 @@ class RegressionStatisticalResults(NamedTuple):
         return reprs
 
 
-class _StatMixin():
-
+class _StatMixin:
     def model_statistics(self):
         """Get the coefficient statistics for this estimator."""
         check_is_fitted(self, attributes=["coef_", "coef_se_"])
@@ -65,7 +64,7 @@ class _StatMixin():
             std_err=self.coef_se_,
             dof=self.dof_,
             t_stat=self.t_,
-            p_value=self.p_
+            p_value=self.p_,
         )
         return stats
 
@@ -81,7 +80,7 @@ class LinearRegressionStat(LinearRegression, _StatMixin):
         s2 = ((self._residues / self.dof_) * np.ones(shp)).T
         self.coef_se_ = np.sqrt(linalg.pinv(X.T @ X).diagonal() * s2)
         self.t_ = self.coef_ / self.coef_se_
-        self.p_ = (1. - stats.t.cdf(np.abs(self.t_), df=self.dof_)) * 2
+        self.p_ = (1.0 - stats.t.cdf(np.abs(self.t_), df=self.dof_)) * 2
         return self
 
 
@@ -95,7 +94,7 @@ class BayesianRidgeStat(BayesianRidge, _StatMixin):
         self.coef_se_ = np.sqrt(self.sigma_.diagonal())
         # NOTE: THIS IS NOT USING THE PROPER POSTERIOR
         self.t_ = self.coef_ / self.coef_se_
-        self.p_ = (1. - stats.t.cdf(np.abs(self.t_), df=self.dof_)) * 2
+        self.p_ = (1.0 - stats.t.cdf(np.abs(self.t_), df=self.dof_)) * 2
         return self
 
 
@@ -146,8 +145,7 @@ class BinaryTreatmentRegressor(BaseEstimator, RegressorMixin):
         self.t_estimator_ = clone(self.estimator)
         self.c_estimator_ = clone(self.estimator)
 
-        Xt, Xc, t_mask = _treatment_split(X, self.treatment_column,
-                                          self.treatment_val)
+        Xt, Xc, t_mask = _treatment_split(X, self.treatment_column, self.treatment_val)
 
         c_mask = ~t_mask
         yt, yc = y[t_mask], y[c_mask]
@@ -162,8 +160,7 @@ class BinaryTreatmentRegressor(BaseEstimator, RegressorMixin):
     def predict(self, X):
         """Predict the outcomes."""
         check_is_fitted(self, attributes=["t_estimator_", "c_estimator_"])
-        Xt, Xc, t_mask = _treatment_split(X, self.treatment_column,
-                                          self.treatment_val)
+        Xt, Xc, t_mask = _treatment_split(X, self.treatment_column, self.treatment_val)
         Ey = np.zeros(len(X))
         if len(Xt) > 0:
             Ey[t_mask] = self.t_estimator_.predict(Xt)
@@ -177,7 +174,7 @@ class BinaryTreatmentRegressor(BaseEstimator, RegressorMixin):
         return {
             "estimator": self.estimator,
             "treatment_column": self.treatment_column,
-            "treatment_val": self.treatment_val
+            "treatment_val": self.treatment_val,
         }
 
     def set_params(self, **parameters: dict):
@@ -194,7 +191,6 @@ def _treatment_split(X, t_col, t_val):
     Xt = X[t_mask]
     Xc = X[~t_mask]
     return Xt, Xc, t_mask
-
 
 
 @multimethod

--- a/cinspect/estimators.py
+++ b/cinspect/estimators.py
@@ -2,17 +2,15 @@
 # Licensed under the Apache 2.0 License.
 """Convenience estimators for causal estimation."""
 
+from typing import NamedTuple, Union
+
 import numpy as np
 import pandas as pd
-
-from typing import NamedTuple, Union
 from multimethod import multimethod
-from scipy import linalg
-from scipy import stats
-
+from scipy import linalg, stats
 from sklearn.base import BaseEstimator, RegressorMixin, clone
+from sklearn.linear_model import BayesianRidge, LinearRegression
 from sklearn.utils.validation import check_is_fitted
-from sklearn.linear_model import LinearRegression, BayesianRidge
 
 
 class RegressionStatisticalResults(NamedTuple):
@@ -73,6 +71,10 @@ class LinearRegressionStat(LinearRegression, _StatMixin):
     """Scikit learn's LinearRegression estimator with coefficient stats."""
 
     def fit(self, X, y, sample_weight=None):
+        """Fit linear regression model to data.
+
+        TODO: complete docstring
+        """
         super().fit(X, y, sample_weight)
         n, d = X.shape
         self.dof_ = n - d
@@ -88,6 +90,10 @@ class BayesianRidgeStat(BayesianRidge, _StatMixin):
     """Scikit learn's BayesianRidge estimator with coefficient stats."""
 
     def fit(self, X, y, sample_weight=None):
+        """Fit bayesian ridge estimator to data.
+
+        TODO: complete docstring
+        """
         super().fit(X, y, sample_weight)
         n, d = X.shape
         self.dof_ = n - d  # NOTE: THIS IS AN UNDERESTIMATE

--- a/cinspect/evaluators.py
+++ b/cinspect/evaluators.py
@@ -382,7 +382,7 @@ class PartialDependanceEvaluator(Evaluator):
         color_samples="grey",
         pd_alpha=None,
         ci_bounds=(0.025, 0.975),
-    ) -> list[mpl.figure.Figure]:
+    ) -> Sequence[mpl.figure.Figure]:
         """Get list of PD plots.
 
         TODO: finish docstring
@@ -402,7 +402,7 @@ class PartialDependanceEvaluator(Evaluator):
 
         Returns
         -------
-        List[mpl.figure.Figure]
+        Sequence[mpl.figure.Figure]
             List of PD plots; one for each dep param
 
         Raises

--- a/cinspect/importance.py
+++ b/cinspect/importance.py
@@ -17,8 +17,9 @@ from sklearn.utils import Bunch, check_array, check_random_state
 from sklearn.utils.validation import _deprecate_positional_args
 
 
-def _calculate_permutation_scores(estimator, X, y, col_idx, random_state,
-                                  n_repeats, scorer):
+def _calculate_permutation_scores(
+    estimator, X, y, col_idx, random_state, n_repeats, scorer
+):
     """Calculate score when `col_idx` is permuted."""
     random_state = check_random_state(random_state)
 
@@ -50,18 +51,23 @@ def _check_feature_dict_valid(features):
     for f_list in features.values():
         for f in f_list:
             if f in result:
-                raise ValueError("features must not be duplicated, even "
-                                 f"under different groups, got:{features}")
+                raise ValueError(
+                    "features must not be duplicated, even "
+                    f"under different groups, got:{features}"
+                )
             if type(f) != int:
-                raise ValueError("keys must map to lists of integers, "
-                                 f"got:{features}")
+                raise ValueError(
+                    "keys must map to lists of integers, " f"got:{features}"
+                )
             result.append(f)
 
 
 def _check_feature_list_valid(features):
     if not all((type(c) == int for c in features)):
-        error_msg = "features must be supplied as a list must all be " \
-                    f"integers, got:{features}"
+        error_msg = (
+            "features must be supplied as a list must all be "
+            f"integers, got:{features}"
+        )
         raise ValueError(error_msg)
 
 
@@ -83,7 +89,7 @@ def permutation_importance(
     n_jobs=None,
     random_state=None,
     features=None,
-    grouped=False
+    grouped=False,
 ):
     """Permutation importance for feature evaluation [BRE]_.
 
@@ -176,14 +182,12 @@ def permutation_importance(
         X = check_array(X, force_all_finite="allow-nan", dtype=None)
 
     if grouped:
-        error_msg = "if grouped is true, features must be passed as a " \
-            "dictionary"
-        assert (hasattr(features, "keys") and
-                hasattr(features, "values")), error_msg
+        error_msg = "if grouped is true, features must be passed as a " "dictionary"
+        assert hasattr(features, "keys") and hasattr(features, "values"), error_msg
         _check_feature_dict_valid(features)
 
     elif features is not None:
-        if (hasattr(features, "keys") and hasattr(features, "values")):
+        if hasattr(features, "keys") and hasattr(features, "values"):
             _check_feature_dict_valid(features)
             features = _flatten_feature_dict(features)
 
@@ -208,11 +212,16 @@ def permutation_importance(
     else:
         column_indexes = features  # each col_indx will be an int
 
-    scores = Parallel(n_jobs=n_jobs)(delayed(_calculate_permutation_scores)(
-        estimator, X, y, col_idx, random_seed, n_repeats, scorer
-    ) for col_idx in column_indexes)
+    scores = Parallel(n_jobs=n_jobs)(
+        delayed(_calculate_permutation_scores)(
+            estimator, X, y, col_idx, random_seed, n_repeats, scorer
+        )
+        for col_idx in column_indexes
+    )
 
     importances = baseline_score - np.array(scores)
-    return Bunch(importances_mean=np.mean(importances, axis=1),
-                 importances_std=np.std(importances, axis=1),
-                 importances=importances)
+    return Bunch(
+        importances_mean=np.mean(importances, axis=1),
+        importances_std=np.std(importances, axis=1),
+        importances=importances,
+    )

--- a/cinspect/model_evaluation.py
+++ b/cinspect/model_evaluation.py
@@ -27,7 +27,7 @@ def crossval_model(
     evaluators: Sequence[Evaluator],
     cv: Optional[Union[int, BaseCrossValidator]] = None,
     random_state: Optional[Union[int, np.random.RandomState]] = None,
-    stratify: Optional[Union[np.ndarray, pd.Series]] = None
+    stratify: Optional[Union[np.ndarray, pd.Series]] = None,
 ) -> Sequence[Evaluator]:
     """
     Evaluate a model using cross validation.
@@ -81,7 +81,7 @@ def bootstrap_model(
     evaluators: Sequence[Evaluator],
     replications: int = 100,
     random_state: Optional[Union[int, np.random.RandomState]] = None,
-    groups: bool = False
+    groups: bool = False,
 ) -> Sequence[Evaluator]:
     """
     Retrain a model using bootstrap re-sampling.
@@ -117,12 +117,14 @@ def bootstrap_model(
         start = time.time()
         Xb, yb, indicesb = resample(X, y, indices)
 
-        if groups :
+        if groups:
             if "groups" in inspect.signature(estimator.fit).parameters.keys():
                 estimator.fit(Xb, yb, groups=indicesb)
             else:
-                LOG.warning("`groups` parameter passed to bootstrap_model, \
-                        but estimator does not support groups. Fitting without groups.")
+                LOG.warning(
+                    "`groups` parameter passed to bootstrap_model, \
+                        but estimator does not support groups. Fitting without groups."
+                )
                 estimator.fit(Xb, yb)
         else:
             estimator.fit(Xb, yb)

--- a/setup.py
+++ b/setup.py
@@ -22,18 +22,14 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="causal_inspection",
-
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
     version="0.0.1",
-
     description="Scikit-learn inspired inspection utilities for causal models",
     long_description=long_description,
-
     # The project"s main homepage.
     url="https://github.com/gradientinstitute/causal_inspection",
-
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         # How mature is this project? Common values are
@@ -41,23 +37,18 @@ setup(
         #   4 - Beta
         #   5 - Production/Stable
         "Development Status :: 3 - Alpha",
-
         # Indicate who your project is intended for
         "Intended Audience :: Developers",
         "Topic :: Statistics :: Causal",
-
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        "Programming Language :: Python :: 3"
+        "Programming Language :: Python :: 3",
     ],
-
     # What does your project relate to?
     keywords="causality inspection interpretability",
-
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
     packages=["cinspect"],
-
     # List run-time dependencies here.  These will be installed by pip when
     # your project is installed. For an analysis of "install_requires" vs pip"s
     # requirements files see:
@@ -68,7 +59,7 @@ setup(
         "pandas",
         "scikit-learn",
         "matplotlib",
-        "multimethod"
+        "multimethod",
     ],
     extras_require={
         "dev": [
@@ -84,7 +75,7 @@ setup(
             "mypy",
             "mypy_extensions",
             "networkx",
-            "hypothesis"
+            "hypothesis",
         ]
-    }
+    },
 )

--- a/simulations/__init__.py
+++ b/simulations/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Gradient Institute. All rights reserved.
+# Licensed under the Apache 2.0 License.
+
+"""Simulations: examples and synthetidc data generation utilities."""

--- a/simulations/datagen.py
+++ b/simulations/datagen.py
@@ -14,7 +14,7 @@ def generate_sythetic_approximation(X: np.ndarray) -> np.ndarray:
     The covariance matrix is used to capture all the relationships between variables,
     regardless of whether they are continuous or categorical.
     """
-    c = X.T@X
+    c = X.T @ X
     Xs = np.random.multivariate_normal(X.mean(axis=0), c, size=len(X))
     for col in range(X.shape[1]):
         vals = np.sort(X[:, col])
@@ -23,7 +23,7 @@ def generate_sythetic_approximation(X: np.ndarray) -> np.ndarray:
     return Xs
 
 
-class DGPGraph():
+class DGPGraph:
     """A high level Interface for building Bayesian network data generating processes.
 
     Example
@@ -116,14 +116,16 @@ class DGPGraph():
 
             s = data.shape
 
-            msg = f"Invalid shape {s} from sample({node},n={n_test}). "\
+            msg = (
+                f"Invalid shape {s} from sample({node},n={n_test}). "
                 "Result for {node} must be np.array(n,) or (n, .)"
+            )
 
             if len(s) not in [1, 2]:
                 raise ValueError(msg)
             else:
                 if s[0] != n_test:
-                    raise(ValueError(msg))
+                    raise (ValueError(msg))
 
             shapes[node] = s
 
@@ -139,7 +141,7 @@ class DGPGraph():
         else:
             raise ValueError(f"Shape for {node} must be one or dimensional but was {s}")
 
-        return v*value
+        return v * value
 
     def draw_graph(self):
         """Draw the DAG for the data generating process."""
@@ -186,8 +188,16 @@ class DGPGraph():
         # TODO add standard error in ate
         return ate
 
-    def cate(self, n, treatment_node, outcome_node, condition_node,
-             condition_values, treatment_val=1, control_val=0):
+    def cate(
+        self,
+        n,
+        treatment_node,
+        outcome_node,
+        condition_node,
+        condition_values,
+        treatment_val=1,
+        control_val=0,
+    ):
         """Compute the estimated Conditional Average Treatment Effect from a sample size n."""
         condition_shape = self.shapes[condition_node]
         if len(condition_shape) > 1:
@@ -201,10 +211,12 @@ class DGPGraph():
 
         result = np.zeros(len(condition_values))
         for i, v in enumerate(condition_values):
-            s1 = self.sample(n, interventions={
-                condition_node: v, treatment_node: treatment_val})
-            s0 = self.sample(n, interventions={
-                condition_node: v, treatment_node: control_val})
+            s1 = self.sample(
+                n, interventions={condition_node: v, treatment_node: treatment_val}
+            )
+            s0 = self.sample(
+                n, interventions={condition_node: v, treatment_node: control_val}
+            )
             cate = s1[outcome_node].mean() - s0[outcome_node].mean()
             result[i] = cate
         return result

--- a/simulations/simple_sim.py
+++ b/simulations/simple_sim.py
@@ -11,8 +11,10 @@ from sklearn.linear_model import Ridge
 from sklearn.model_selection import GridSearchCV
 
 from cinspect.model_evaluation import bootstrap_model
-from cinspect.evaluators import (PartialDependanceEvaluator,
-                                 PermutationImportanceEvaluator)
+from cinspect.evaluators import (
+    PartialDependanceEvaluator,
+    PermutationImportanceEvaluator,
+)
 from simulations.datagen import DGPGraph
 
 
@@ -20,10 +22,7 @@ from simulations.datagen import DGPGraph
 LOG = logging.getLogger(__name__)
 
 # Log INFO to STDOUT
-logging.basicConfig(
-    level=logging.INFO,
-    handlers=[logging.StreamHandler()]
-)
+logging.basicConfig(level=logging.INFO, handlers=[logging.StreamHandler()])
 
 
 def data_generation(n_x=30, support_size=5):

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -2,7 +2,10 @@
 # Licensed under the Apache 2.0 License.
 """Test the estimators."""
 
+"""Stub of imports:
+
 import pytest
 
 from sklearn.linear_model import LinearRegression
 from cinspect.estimators import BinaryTreatmentRegressor
+"""

--- a/tests/test_evaluators.py
+++ b/tests/test_evaluators.py
@@ -2,7 +2,9 @@
 # Licensed under the Apache 2.0 License.
 """Test for the evaluators module."""
 
+""" Stub of imports:
 from cinspect.evaluators import Evaluator, ScoreEvaluator
+"""
 
 
 def test_evaluator_calls():

--- a/tests/test_model_evaluation.py
+++ b/tests/test_model_evaluation.py
@@ -16,6 +16,7 @@ from numpy.random.mtrand import RandomState
 from sklearn.base import BaseEstimator
 from sklearn.dummy import DummyRegressor
 from sklearn.linear_model import LinearRegression
+
 # KFold,; GroupKFold,; LeaveOneGroupOut,; StratifiedGroupKFold,; StratifiedKFold,
 from sklearn.model_selection._split import LeaveOneOut, TimeSeriesSplit
 from sklearn.utils.validation import check_random_state

--- a/tests/test_model_evaluation.py
+++ b/tests/test_model_evaluation.py
@@ -1,7 +1,6 @@
 # Copyright (c) Gradient Institute. All rights reserved.
 # Licensed under the Apache 2.0 License.
 """Tests for model_evaluation module."""
-import itertools
 import logging
 from typing import Callable
 
@@ -17,9 +16,8 @@ from numpy.random.mtrand import RandomState
 from sklearn.base import BaseEstimator
 from sklearn.dummy import DummyRegressor
 from sklearn.linear_model import LinearRegression
-
-# GroupKFold,; LeaveOneGroupOut,; StratifiedGroupKFold,; StratifiedKFold,
-from sklearn.model_selection._split import KFold, LeaveOneOut, TimeSeriesSplit
+# KFold,; GroupKFold,; LeaveOneGroupOut,; StratifiedGroupKFold,; StratifiedKFold,
+from sklearn.model_selection._split import LeaveOneOut, TimeSeriesSplit
 from sklearn.utils.validation import check_random_state
 
 import testing_strategies


### PR DESCRIPTION
Addresses issue #3:
- code passes flake8 linting
    - passed through `black` formatter and manually fixed residual errors 
    - note: `black` and `flake8` seem to disagree on whether to slice like `[start:stop]` or `[start : stop]`
- added docstrings
    - some of which are stubs, where cost/benefit of grokking whole function seemed too high. Indicated with TODOs

It might be a good idea to incorporate linting into CI or similar