### PR TITLE
simplify evaluator interface, kwargs and groups

### DIFF
--- a/cinspect/importance.py
+++ b/cinspect/importance.py
@@ -100,7 +100,7 @@ def permutation_importance(
     dataset defined by the `X`. Next, a feature column from the validation set
     is permuted and the metric is evaluated again. The permutation importance
     is defined to be the difference between the baseline metric and metric from
-    permutating the feature column.
+    permuting the feature column.
 
     Read more in the :ref:`User Guide <permutation_importance>`.
 
@@ -137,14 +137,14 @@ def permutation_importance(
         See :term: `Glossary <random_state>`.
 
     features: [int] or {str:[int]}, default=None
-        Either a list of feature indices for which importance should be computed
-        or a dictionary from name -> list of indices. If a dictionary and `grouped` is true
-        then features corresponding to the same key will be permuted together.
-        By default, compute importance for all features.
+        Either a list of feature indices for which importance should be
+        computed or a dictionary from name -> list of indices. If a dictionary
+        and `grouped` is true then features corresponding to the same key will
+        be permuted together. By default, compute importance for all features.
 
     grouped: bool, default=False
-        Should the supplied features be permuted together within specified groups.
-        If True, features must be supplied as a dict.
+        Should the supplied features be permuted together within specified
+        groups. If True, features must be supplied as a dict.
 
     Returns
     -------

--- a/simulations/collinear_sim.py
+++ b/simulations/collinear_sim.py
@@ -129,7 +129,7 @@ def load_synthetic_data():
 def main():
     """Run the simulation."""
     alpha_range = np.logspace(-1, 4, 30)
-    replications = 20
+    replications = 6
 
     # X, Y = load_synthetic_data()
     X, Y = make_data()
@@ -183,14 +183,17 @@ def main():
     if "ridge_gs" in models:
         bteval = BinaryTreatmentEffect(treatment_column="T")  # all data used
         bootstrap_model(
-            ridge_gs, X, Y, [bteval], replications=replications, groups=True
+            ridge_gs, X, Y, [bteval], replications=replications,
+            cross_eval=True
         )
         results["ridge_gs"]["Bootstrap-group"] = bteval.get_results()
 
     if "btr" in models:
         btr = BinaryTreatmentRegressor(ridge_gs_g, "T", 1.0)
         bteval = BinaryTreatmentEffect(treatment_column="T")  # all data used
-        bootstrap_model(btr, X, Y, [bteval], replications=replications, groups=True)
+        bootstrap_model(
+            btr, X, Y, [bteval], replications=replications, cross_eval=True
+        )
         results["btr"]["Bootstrap-group"] = bteval.get_results()
 
     # Print results:

--- a/tests/test_model_evaluation.py
+++ b/tests/test_model_evaluation.py
@@ -40,39 +40,23 @@ class _MockEstimator(BaseEstimator):
 
 class _MockEvaluator(Evaluator):
     def __init__(self):
-        self.eval_all = False
-        self.eval_test = False
-        self.eval_train = False
+        self.eval = False
         self.prepare_call = False
         self.aggregate_call = False
 
     def prepare(self, estimator, X, y=None, random_state=None):
         assert not estimator.is_fitted
-        assert not self.eval_all
-        assert not self.eval_train
-        assert not self.eval_test
+        assert not self.eval
         assert not self.aggregate_call
         self.prepare_call = True
 
-    def evaluate_all(self, estimator, X, y=None):
+    def evaluate(self, estimator, X, y=None):
         assert estimator.is_fitted
         assert not self.aggregate_call
-        self.eval_all = True
-
-    def evaluate_test(self, estimator, X=None, y=None):
-        assert estimator.is_fitted
-        assert not self.aggregate_call
-        self.eval_test = True
-
-    def evaluate_train(self, estimator, X, y):
-        assert estimator.is_fitted
-        assert not self.aggregate_call
-        self.eval_train = True
+        self.eval = True
 
     def aggregate(self, name=None, estimator_score=None, outdir=None):
-        assert self.eval_all
-        assert self.eval_train
-        assert self.eval_test
+        assert self.eval
         self.aggregate_call = True
 
 
@@ -101,7 +85,7 @@ class _MockRandomEvaluator(Evaluator):
         """Initialise using data; in this case, only the random state is used."""
         self._random_state = random_state
 
-    def _evaluate(self, estimator, X, y):
+    def evaluate(self, estimator, X, y):
         """Evaluate estimator; in this case, the evaluation is random."""
         # pass through/seed/create new rng as appropriate
         self._random_state = check_random_state(self._random_state)
@@ -110,10 +94,6 @@ class _MockRandomEvaluator(Evaluator):
         self._results.append(result)
 
         return result
-
-    evaluate_all = _evaluate
-    evaluate_train = _evaluate
-    evaluate_test = _evaluate
 
     def get_results(self):
         """Return (random) evaluation."""


### PR DESCRIPTION
This feature is half done - but to do it properly I had to go ahead and simplify the interface to the evaluators. I figure it may be useful to merge this in, then I'll keep going with it. I think we'll need another model evaluation method for this.

I've also fixed a small issue in the `groups` checking code in `bootstrap_model` to allow fit methods with kwargs.