### PR TITLE
Feature6

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ pieval.get_results(ntop=5)  # Permutation importance, show top 5 features
 plt.show()
 ```
 
+See `simulations/simple_sim.py` for a slightly more complex version where we
+integrate model selection within the bootstrap sampling procedure.
+
 
 References
 ----------

--- a/simulations/collinear_sim.py
+++ b/simulations/collinear_sim.py
@@ -129,7 +129,7 @@ def load_synthetic_data():
 def main():
     """Run the simulation."""
     alpha_range = np.logspace(-1, 4, 30)
-    replications = 6
+    replications = 10
 
     # X, Y = load_synthetic_data()
     X, Y = make_data()
@@ -183,8 +183,7 @@ def main():
     if "ridge_gs" in models:
         bteval = BinaryTreatmentEffect(treatment_column="T")  # all data used
         bootstrap_model(
-            ridge_gs, X, Y, [bteval], replications=replications,
-            cross_eval=True
+            ridge_gs, X, Y, [bteval], replications=replications, groups=True
         )
         results["ridge_gs"]["Bootstrap-group"] = bteval.get_results()
 
@@ -192,7 +191,7 @@ def main():
         btr = BinaryTreatmentRegressor(ridge_gs_g, "T", 1.0)
         bteval = BinaryTreatmentEffect(treatment_column="T")  # all data used
         bootstrap_model(
-            btr, X, Y, [bteval], replications=replications, cross_eval=True
+            btr, X, Y, [bteval], replications=replications, groups=True
         )
         results["btr"]["Bootstrap-group"] = bteval.get_results()
 


### PR DESCRIPTION
Implements bootstrap cross evaluation.

I feel like we could simplify the `groups` interface in this and in `bootstrap_model` interfaces - or at least detect when an estimator can accept groups and automatically use them - and warn a user when not using groups and `GridSearchCV` is used?