### PR TITLE
Reproducible Simulations

### DIFF
--- a/simulations/collinear_sim.py
+++ b/simulations/collinear_sim.py
@@ -13,16 +13,11 @@ from cinspect.evaluators import BinaryTreatmentEffect
 from cinspect.model_evaluation import bootstrap_model, crossval_model
 from numpy.typing import ArrayLike
 from scipy.special import expit
-
 # from sklearn.base import clone # required if we add *best* ridge regressor back in
 from sklearn.kernel_approximation import RBFSampler
 from sklearn.linear_model import Ridge
-from sklearn.model_selection import (
-    GridSearchCV,
-    GroupKFold,
-    RepeatedKFold,
-    ShuffleSplit,
-)
+from sklearn.model_selection import (GridSearchCV, GroupKFold, RepeatedKFold,
+                                     ShuffleSplit)
 from sklearn.utils import check_random_state
 
 from simulations.datagen import DGPGraph
@@ -57,7 +52,7 @@ def data_generation(confounder_dim=200, latent_dim=5, random_state=None):
     cov_x = A @ A.T / latent_dim
 
     # Projection class
-    rbf = RBFSampler(n_components=confounder_dim, gamma=1.0)
+    rbf = RBFSampler(n_components=confounder_dim, gamma=1.0, random_state=random_state)
     rbf.fit(rng.randn(2, latent_dim))
 
     # Treatment properties

--- a/simulations/collinear_sim.py
+++ b/simulations/collinear_sim.py
@@ -13,11 +13,16 @@ from cinspect.evaluators import BinaryTreatmentEffect
 from cinspect.model_evaluation import bootstrap_model, crossval_model
 from numpy.typing import ArrayLike
 from scipy.special import expit
+
 # from sklearn.base import clone # required if we add *best* ridge regressor back in
 from sklearn.kernel_approximation import RBFSampler
 from sklearn.linear_model import Ridge
-from sklearn.model_selection import (GridSearchCV, GroupKFold, RepeatedKFold,
-                                     ShuffleSplit)
+from sklearn.model_selection import (
+    GridSearchCV,
+    GroupKFold,
+    RepeatedKFold,
+    ShuffleSplit,
+)
 from sklearn.utils import check_random_state
 
 from simulations.datagen import DGPGraph

--- a/tests/test_simple_sim.py
+++ b/tests/test_simple_sim.py
@@ -1,0 +1,32 @@
+"""Test simulations/simple_sim.py"""
+import hypothesis as hyp
+import numpy as np
+from hypothesis import given
+from hypothesis import strategies as st
+from simulations import simple_sim
+
+
+@st.composite
+def n_x_support_strat(draw):
+    n_x = draw(st.integers(min_value=0, max_value=10))
+    support = draw(st.integers(min_value=0, max_value=n_x))
+    return (n_x, support)
+
+
+@given(
+    n_x=st.shared(n_x_support_strat(), key="nxs").map(lambda tup: tup[0]),
+    support_size=st.shared(n_x_support_strat(), key="nxs").map(lambda tup: tup[1]),
+    random_state=st.one_of(st.integers(min_value=0, max_value=2**32 - 1)),
+)
+def test_data_generation_deterministic(n_x, support_size, random_state):
+    result = simple_sim.data_generation(n_x, support_size, random_state)
+    repeat = simple_sim.data_generation(n_x, support_size, random_state)
+    X_res = result.sample(100)
+    X_rep = repeat.sample(100)
+    same_results = _dicts_of_arrays_equal(X_res, X_rep)
+    assert same_results
+
+
+def _dicts_of_arrays_equal(d1, d2):
+    key_els_equal = [np.array_equal(d1[k], d2[k]) for k in list(d1.keys()) + list(d2.keys())]
+    return all(key_els_equal)

--- a/tests/test_sims.py
+++ b/tests/test_sims.py
@@ -1,4 +1,4 @@
-"""Test simulations/simple_sim.py"""
+"""Simulations tests"""
 import hypothesis as hyp
 import numpy as np
 from hypothesis import given
@@ -18,14 +18,29 @@ def n_x_support_strat(draw):
     support_size=st.shared(n_x_support_strat(), key="nxs").map(lambda tup: tup[1]),
     random_state=st.one_of(st.integers(min_value=0, max_value=2**32 - 1)),
 )
-def test_data_generation_deterministic(n_x, support_size, random_state):
+def test_simple_data_generation_deterministic(n_x, support_size, random_state):
     result = simple_sim.data_generation(n_x, support_size, random_state)
     repeat = simple_sim.data_generation(n_x, support_size, random_state)
+    # sample from the dgps and compare samples for equality
     X_res = result.sample(100)
     X_rep = repeat.sample(100)
     same_results = _dicts_of_arrays_equal(X_res, X_rep)
     assert same_results
 
+
+@given(
+    confounder_dims=st.shared(n_x_support_strat(), key="nxs").map(lambda tup: tup[0]),
+    latent_dims=st.shared(n_x_support_strat(), key="nxs").map(lambda tup: tup[1]),
+    random_state=st.one_of(st.integers(min_value=0, max_value=2**32 - 1)),
+)
+def test_collinear_data_generation_deterministic(confounder_dims, latent_dims, random_state):
+    result = simple_sim.data_generation(confounder_dims, latent_dims, random_state)
+    repeat = simple_sim.data_generation(confounder_dims, latent_dims, random_state)
+    # sample from the dgps and compare samples for equality
+    X_res = result.sample(100)
+    X_rep = repeat.sample(100)
+    same_results = _dicts_of_arrays_equal(X_res, X_rep)
+    assert same_results
 
 def _dicts_of_arrays_equal(d1, d2):
     key_els_equal = [np.array_equal(d1[k], d2[k]) for k in list(d1.keys()) + list(d2.keys())]

--- a/tests/test_sims.py
+++ b/tests/test_sims.py
@@ -1,5 +1,5 @@
-"""Simulations tests"""
-import hypothesis as hyp
+"""Simulations tests."""
+
 import numpy as np
 from hypothesis import given
 from hypothesis import strategies as st
@@ -7,15 +7,15 @@ from simulations import collinear_sim, simple_sim
 
 
 @st.composite
-def n_x_support_strat(draw):
+def _n_x_support_strat(draw):
     n_x = draw(st.integers(min_value=0, max_value=10))
     support = draw(st.integers(min_value=0, max_value=n_x))
     return (n_x, support)
 
 
 @given(
-    n_x=st.shared(n_x_support_strat(), key="nxs").map(lambda tup: tup[0]),
-    support_size=st.shared(n_x_support_strat(), key="nxs").map(lambda tup: tup[1]),
+    n_x=st.shared(_n_x_support_strat(), key="nxs").map(lambda tup: tup[0]),
+    support_size=st.shared(_n_x_support_strat(), key="nxs").map(lambda tup: tup[1]),
     random_state=st.one_of(st.integers(min_value=0, max_value=2**32 - 1)),
 )
 def test_simple_data_generation_deterministic(n_x, support_size, random_state):

--- a/tests/test_sims.py
+++ b/tests/test_sims.py
@@ -3,7 +3,7 @@ import hypothesis as hyp
 import numpy as np
 from hypothesis import given
 from hypothesis import strategies as st
-from simulations import simple_sim
+from simulations import collinear_sim, simple_sim
 
 
 @st.composite
@@ -29,13 +29,13 @@ def test_simple_data_generation_deterministic(n_x, support_size, random_state):
 
 
 @given(
-    confounder_dims=st.shared(n_x_support_strat(), key="nxs").map(lambda tup: tup[0]),
-    latent_dims=st.shared(n_x_support_strat(), key="nxs").map(lambda tup: tup[1]),
+    confounder_dims=st.integers(min_value=1, max_value=100),# st.shared(n_x_support_strat(), key="nxs").map(lambda tup: tup[0]),
+    latent_dims=st.integers(min_value=1, max_value=100), #st.shared(n_x_support_strat(), key="nxs").map(lambda tup: tup[1]),
     random_state=st.one_of(st.integers(min_value=0, max_value=2**32 - 1)),
 )
 def test_collinear_data_generation_deterministic(confounder_dims, latent_dims, random_state):
-    result = simple_sim.data_generation(confounder_dims, latent_dims, random_state)
-    repeat = simple_sim.data_generation(confounder_dims, latent_dims, random_state)
+    result = collinear_sim.data_generation(confounder_dims, latent_dims, random_state)
+    repeat = collinear_sim.data_generation(confounder_dims, latent_dims, random_state)
     # sample from the dgps and compare samples for equality
     X_res = result.sample(100)
     X_rep = repeat.sample(100)

--- a/tests/test_sims.py
+++ b/tests/test_sims.py
@@ -19,6 +19,10 @@ def n_x_support_strat(draw):
     random_state=st.one_of(st.integers(min_value=0, max_value=2**32 - 1)),
 )
 def test_simple_data_generation_deterministic(n_x, support_size, random_state):
+    """Test that the simple simulation runs deterministically.
+
+    Samples from two DGPS constructed with same parameters.
+    """
     result = simple_sim.data_generation(n_x, support_size, random_state)
     repeat = simple_sim.data_generation(n_x, support_size, random_state)
     # sample from the dgps and compare samples for equality
@@ -29,11 +33,17 @@ def test_simple_data_generation_deterministic(n_x, support_size, random_state):
 
 
 @given(
-    confounder_dims=st.integers(min_value=1, max_value=100),# st.shared(n_x_support_strat(), key="nxs").map(lambda tup: tup[0]),
-    latent_dims=st.integers(min_value=1, max_value=100), #st.shared(n_x_support_strat(), key="nxs").map(lambda tup: tup[1]),
+    confounder_dims=st.integers(min_value=1, max_value=100),
+    latent_dims=st.integers(min_value=1, max_value=100),
     random_state=st.one_of(st.integers(min_value=0, max_value=2**32 - 1)),
 )
-def test_collinear_data_generation_deterministic(confounder_dims, latent_dims, random_state):
+def test_collinear_data_generation_deterministic(
+    confounder_dims, latent_dims, random_state
+):
+    """Test that the collinear simulation runs deterministically.
+
+    Samples from two DGPS constructed with same parameters.
+    """
     result = collinear_sim.data_generation(confounder_dims, latent_dims, random_state)
     repeat = collinear_sim.data_generation(confounder_dims, latent_dims, random_state)
     # sample from the dgps and compare samples for equality
@@ -42,6 +52,9 @@ def test_collinear_data_generation_deterministic(confounder_dims, latent_dims, r
     same_results = _dicts_of_arrays_equal(X_res, X_rep)
     assert same_results
 
+
 def _dicts_of_arrays_equal(d1, d2):
-    key_els_equal = [np.array_equal(d1[k], d2[k]) for k in list(d1.keys()) + list(d2.keys())]
+    key_els_equal = [
+        np.array_equal(d1[k], d2[k]) for k in list(d1.keys()) + list(d2.keys())
+    ]
     return all(key_els_equal)


### PR DESCRIPTION
Makes `collinear_sim` and `simple_sim` use random seeds.

`datagen.DGPGraph` did not need to be changed; random sampling is done in the functions *passed* to the graph, so seeds can be managed by the caller. This seems like a good design to me; it makes it very easy to reuse the DGPGraph (as evidenced by how easy these changes were to make.

I've added tests to check for determinism of simulations as well; this was immediately valuable as I had forgotten to pass a seed to an object in `collinear_sim`.