### PR TITLE
clean up group interface, closes #26

### DIFF
--- a/simulations/simple_sim.py
+++ b/simulations/simple_sim.py
@@ -106,9 +106,8 @@ def main():
     # Casual estimation
     pdeval = PartialDependanceEvaluator(feature_grids={"T": "auto"})
     pieval = PermutationImportanceEvaluator(n_repeats=5)
-    bootcross_model(
-        model, X, Y, [pdeval, pieval], replications=30, groups=True
-    )  # Note groups=True for GroupKFold
+    bootcross_model(model, X, Y, [pdeval, pieval], replications=30,
+                    use_group_cv=True)  # To make sure we pass use GroupKFold
 
     pdeval.get_results(mode="interval")
     pdeval.get_results(mode="derivative")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+# Copyright (c) Gradient Institute. All rights reserved.
+# Licensed under the Apache 2.0 License.
+"""Test fixtures."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def make_simple_data():
+    """Make a simple X, y dataset."""
+    X, y = pd.DataFrame(np.ones((100, 2))), pd.Series(np.ones(100))
+    return X, y


### PR DESCRIPTION
So - after exploring a bunch of things, I decided the current interface is probably the most obvious. I just cleaned it up a little.

This is because the insane amount of possible inheritance and nesting of objects in scikit learn makes it really hard to detect if an estimator actually requires or can use "groups" in its `fit` method....