### PR TITLE
Modify Evaluator for parallel execution

### DIFF
--- a/cinspect/dependence.py
+++ b/cinspect/dependence.py
@@ -3,7 +3,7 @@
 """Partial dependence and individual conditional expectation functions."""
 
 import numbers
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -139,7 +139,7 @@ def construct_grid(
     grid_counts = None
     grid = None
 
-    if isinstance(grid_values, Union[List, Tuple, np.ndarray]):
+    if isinstance(grid_values, (List, Tuple, np.ndarray)):
         # check grid_values is not an array,
         # as np.array==str raises a futurewarning
         grid_values = np.asarray(grid_values)

--- a/cinspect/evaluators.py
+++ b/cinspect/evaluators.py
@@ -688,11 +688,12 @@ def _merge_dicts_of_lists_by_concatting(
 
     Not commutative (as list concatenation is not commutative), but not lossy.
 
-    >>> _merge_dicts_of_lists_by_concatting({"k1": [1,2], "k2": [3]}, {"k1": [4], "k3": [5]})
-    {"k1": [1,2,4], "k2": [3], "k3": [5]}
+    >>> merged = _merge_dicts_of_lists_by_concatting({"k1": [1,2], "k2": [3]}, {"k1": [4], "k3": [5]})
+    >>> merged == {"k1": [1,2,4], "k2": [3], "k3": [5]}
+    True
     """
     merged_dict = {
-        k: dict1.get(k, default=[]) + dict2.get(k, default=[])
-        for k in dict1.keys() + dict2.keys()
+        k: dict1.get(k, []) + dict2.get(k, [])
+        for k in set(dict1.keys()).union(set(dict2.keys()))
     }
     return merged_dict

--- a/cinspect/evaluators.py
+++ b/cinspect/evaluators.py
@@ -59,7 +59,7 @@ class Evaluator:
 
         Parameters
         ----------
-        evaluation : Evaluation
+        evaluation:Evaluation
             The new internal evaluation.
         """
         self.evaluation = evaluation
@@ -76,9 +76,11 @@ class Evaluator:
         This could be a pandas dataframe, a matplotlib figure, etc.
         """
         evaluation = (
-            evaluation if evaluation is not None else getattr(self, "evaluation", None)
+            evaluation
+            if evaluation is not None
+            else (self.evaluation if hasattr(self, "evaluation") else None)
         )
-        return self.evaluation
+        return evaluation
 
 
 class ScoreEvaluator(Evaluator):
@@ -152,13 +154,13 @@ class BinaryTreatmentEffect(Evaluator):
 
         Parameters
         ----------
-        treatment_column : Union[str, int]
+        treatment_column:Union[str, int]
             Treatment variable's column index
-        treatment_val : Any, optional
+        treatment_val:Any, optional
             Value of treatment variable when "treated" , by default 1
-        control_val : Any, optional
+        control_val:Any, optional
             Value of treatment variable when "untreated", by default 0
-        evaluate_mode : str, optional
+        evaluate_mode:str, optional
             Evaluation mode; "train"/"test"/"all", by default "all"
         """
         self.treatment_column = treatment_column
@@ -206,7 +208,7 @@ class BinaryTreatmentEffect(Evaluator):
         """Aggregate a sequence of BTEEvaluations to a single BTEEvaluation."""
         return _flatten(evaluations)
 
-    def get_results(self, evaluation, ci_probs=(0.025, 0.975)):
+    def get_results(self, evaluation=None, ci_probs=(0.025, 0.975)):
         """Get the statistics of the ATE.
 
         Parameters
@@ -223,7 +225,7 @@ class BinaryTreatmentEffect(Evaluator):
             A sequence of confidence interval levels as specified by
             `ci_probs`.
         """
-        evaluation = self.super().get_results(evaluation)
+        evaluation = super().get_results(evaluation)
         for p in ci_probs:
             if p < 0 or p > 1:
                 raise ValueError("ci_probs must be in range [0, 1].")
@@ -338,7 +340,7 @@ class PartialDependanceEvaluator(Evaluator):
 
     def get_results(
         self,
-        evaluation: PDEvaluation,
+        evaluation: Optional[PDEvaluation] = None,
         mode="multiple-pd-lines",
         color="black",
         color_samples="grey",
@@ -351,16 +353,16 @@ class PartialDependanceEvaluator(Evaluator):
 
         Parameters
         ----------
-        evaluation : PDEvaluation
-        mode : str, optional
+        evaluation: PDEvaluation
+        mode: str, optional
             _description_, by default "multiple-pd-lines"
-        color : str, optional
+        color: str, optional
             _description_, by default "black"
-        color_samples : str, optional
+        color_samples: str, optional
             _description_, by default "grey"
-        pd_alpha : _type_, optional
+        pd_alpha: _type_, optional
             _description_, by default None
-        ci_bounds : tuple, optional
+        ci_bounds: tuple, optional
             _description_, by default (0.025, 0.975)
 
         Returns
@@ -376,7 +378,7 @@ class PartialDependanceEvaluator(Evaluator):
         RuntimeError
             Raised if a dependency is invalid.
         """
-        evaluation = self.super().get_results(evaluation)
+        evaluation = super().get_results(evaluation)
         figs, ress = {}, {}
         for dep_name, dep in self.dep_params.items():
             predictions = evaluation[dep_name]
@@ -572,14 +574,14 @@ class PermutationImportanceEvaluator(Evaluator):
         """Concatenate sequence of evaluations."""
         return _flatten(evaluations)
 
-    def get_results(self, evaluation, ntop=10, name=None) -> mpl.figure.Figure:
+    def get_results(self, evaluation=None, ntop=10, name=None) -> mpl.figure.Figure:
         """Get permutation importance plot.
 
         Parameters
         ----------
-        ntop : int, optional
+        ntop: int, optional
             Number of features to show on the plot, by default 10
-        name : str, optional
+        name: str, optional
             Name to place on plot, by default None
 
         Returns
@@ -587,7 +589,7 @@ class PermutationImportanceEvaluator(Evaluator):
         mpl.figure.Figure
             Permutation importance figure
         """
-        evaluation = self.super().get_results(evaluation)
+        evaluation = super().get_results(evaluation)
         samples = np.hstack(evaluation)
         name = name + " " if name is not None else ""
         title = f"{name}Permutation Importance"

--- a/cinspect/evaluators.py
+++ b/cinspect/evaluators.py
@@ -714,7 +714,9 @@ def _merge_dicts_of_lists_by_concatting(
 
     Not commutative (as list concatenation is not commutative), but not lossy.
 
-    >>> merged = _merge_dicts_of_lists_by_concatting({"k1": [1,2], "k2": [3]}, {"k1": [4], "k3": [5]})
+    >>> merged = _merge_dicts_of_lists_by_concatting(
+    ...     {"k1": [1,2], "k2": [3]},
+    ...     {"k1": [4], "k3": [5]})
     >>> merged == {"k1": [1,2,4], "k2": [3], "k3": [5]}
     True
     """

--- a/cinspect/evaluators.py
+++ b/cinspect/evaluators.py
@@ -255,7 +255,7 @@ class PartialDependanceEvaluator(Evaluator):
         displayed on plot to provide info about filter
     """
 
-    PDEvaluation = Dict[str, list[npt.ArrayLike]]
+    PDEvaluation = Dict[str, List[npt.ArrayLike]]
 
     def __init__(
         self,

--- a/cinspect/evaluators.py
+++ b/cinspect/evaluators.py
@@ -2,13 +2,16 @@
 # Licensed under the Apache 2.0 License.
 """Result evaluator classes."""
 
+import functools
 import logging
+import operator
 from collections import defaultdict
-from typing import Any, Sequence, Union
+from typing import Any, Dict, List, Sequence, TypeVar, Union
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 from scipy.stats.mstats import mquantiles
 from sklearn.base import clone
@@ -17,6 +20,8 @@ from sklearn.metrics import get_scorer
 from cinspect import dependence, importance
 
 LOG = logging.getLogger(__name__)
+
+Evaluation = TypeVar("Evaluation")
 
 
 class Evaluator:
@@ -29,22 +34,24 @@ class Evaluator:
         """
         pass
 
-    def evaluate(self, estimator, X, y=None):
+    def evaluate(self, estimator, X, y=None) -> Evaluation:
         """Evaluate the fitted estimator with test, training or all data.
+
+        Subclasses should ensure that this is a pure function.
 
         This is called by a model evaluation function in model_evaluation.
         """
         pass
 
-    def aggregate(self):
+    def aggregate(self, evaluations: Sequence[Evaluation]) -> Evaluation:
         """Aggregate the evaluation results.
 
         This is called by a model evaluation function in model_evaluation.
         """
         pass
 
-    def get_results(self):
-        """Get the results from the evaluator.
+    def get_results(self, evaluation: Evaluation) -> Any:
+        """View the evaluator's results.
 
         This could be a pandas dataframe, a matplotlib figure, etc.
         This is called by the end user explicitly.
@@ -83,21 +90,23 @@ class ScoreEvaluator(Evaluator):
 
         This is called by a model evaluation function in model_evaluation.
         """
+        scores = defaultdict(list)
         if self.groupby is not None:
             groups = X.groupby(self.groupby)
             for group_key, Xs in groups:
                 ys = y[Xs.index]
-                self.scores["group"].append(group_key)
+                scores["group"].append(group_key)
                 for s_name, s in self.scorers.items():
-                    self.scores[s_name].append(s(estimator, Xs, ys))
+                    scores[s_name].append(s(estimator, Xs, ys))
 
         else:
             for s_name, s in self.scorers.items():
-                self.scores[s_name].append(s(estimator, X, y))
+                scores[s_name].append(s(estimator, X, y))
+        return scores
 
-    def get_results(self):
+    def get_results(self, evaluation, **kwargs):
         """Get the scores of the estimator."""
-        dfscores = pd.DataFrame(self.scores)
+        dfscores = pd.DataFrame(evaluation)
         return dfscores
 
 
@@ -106,6 +115,8 @@ class BinaryTreatmentEffect(Evaluator):
 
     NOTE: This assumes SUTVA holds.
     """
+
+    BTEEvaluation = List[float]
 
     def __init__(
         self,
@@ -130,7 +141,6 @@ class BinaryTreatmentEffect(Evaluator):
         self.treatment_column = treatment_column
         self.treatment_val = treatment_val
         self.control_val = control_val
-        self.ate_samples = []
 
     def prepare(self, estimator, X, y, random_state=None):
         """Prepare the evaluator with model and data information.
@@ -148,8 +158,8 @@ class BinaryTreatmentEffect(Evaluator):
         # assert self.treatment_val in T
         # assert self.control_val in T
 
-    def evaluate(self, estimator, X, y=None):
-        """Estimate the binary treatment effect on input data.
+    def evaluate(self, estimator, X, y=None) -> BTEEvaluation:
+        """Estimate the binary treatment effect on input data. Returns a singleton list.
 
         This is called by a model evaluation function in model_evaluation.
         """
@@ -166,9 +176,14 @@ class BinaryTreatmentEffect(Evaluator):
 
         # ATE
         ate = np.mean(Ey_treated - Ey_control)
-        self.ate_samples.append(ate)
 
-    def get_results(self, ci_probs=(0.025, 0.975)):
+        return [ate]
+
+    def aggregate(self, evaluations: Sequence[BTEEvaluation]) -> BTEEvaluation:
+        """Aggregate a sequence of BTEEvaluations to a single BTEEvaluation."""
+        return _flatten(evaluations)
+
+    def get_results(self, evaluation, ci_probs=(0.025, 0.975)):
         """Get the statistics of the ATE.
 
         Parameters
@@ -188,8 +203,9 @@ class BinaryTreatmentEffect(Evaluator):
         for p in ci_probs:
             if p < 0 or p > 1:
                 raise ValueError("ci_probs must be in range [0, 1].")
-        mean_ate = np.mean(self.ate_samples)
-        ci_levels = mquantiles(self.ate_samples, ci_probs)
+        ate_samples = evaluation
+        mean_ate = np.mean(ate_samples)
+        ci_levels = mquantiles(ate_samples, ci_probs)
         return mean_ate, *ci_levels
 
 
@@ -214,6 +230,8 @@ class PartialDependanceEvaluator(Evaluator):
     filter_name: (optional) str
         displayed on plot to provide info about filter
     """
+
+    PDEvaluation = Dict[str, list[npt.ArrayLike]]
 
     def __init__(
         self,
@@ -247,9 +265,7 @@ class PartialDependanceEvaluator(Evaluator):
         dep_params = {}
         if self.feature_grids is not None:
             for feature_name, grid_values in self.feature_grids.items():
-                dep_params[feature_name] = _Dependance(
-                    X, feature_name, grid_values
-                )
+                dep_params[feature_name] = _Dependance(X, feature_name, grid_values)
         else:
             for feature_name in X.columns:
                 dep_params[feature_name] = _Dependance(X, feature_name)
@@ -273,6 +289,8 @@ class PartialDependanceEvaluator(Evaluator):
         if self.conditional_filter is not None:
             Xt = self.conditional_filter(Xt)
 
+        param_predictions = defaultdict(list)
+
         for feature_name, params in self.dep_params.items():
             if feature_name not in Xt.columns:
                 raise RuntimeError(f"{feature_name} not in X!")
@@ -283,10 +301,20 @@ class PartialDependanceEvaluator(Evaluator):
                 ice = dependence.individual_conditional_expectation(
                     predictor, Xt, feature_indx, grid
                 )
-                params.predictions.append(ice)
+                param_predictions[feature_name].append(ice)
+        return param_predictions
+
+    def aggregate(self, evaluations: Sequence[PDEvaluation]) -> PDEvaluation:
+        """Aggregate a sequence of PDEvaluations to a single PDEvaluation."""
+        param_predictions_dicts = evaluations
+        combined_predictions = functools.reduce(
+            _merge_dicts_of_lists_by_concatting, param_predictions_dicts
+        )
+        return combined_predictions
 
     def get_results(
         self,
+        evaluation: PDEvaluation,
         mode="multiple-pd-lines",
         color="black",
         color_samples="grey",
@@ -299,6 +327,7 @@ class PartialDependanceEvaluator(Evaluator):
 
         Parameters
         ----------
+        evaluation : PDEvaluation
         mode : str, optional
             _description_, by default "multiple-pd-lines"
         color : str, optional
@@ -324,14 +353,15 @@ class PartialDependanceEvaluator(Evaluator):
             Raised if a dependency is invalid.
         """
         figs, ress = {}, {}
-        for dep in self.dep_params.values():
+        for dep_name, dep in self.dep_params.items():
+            predictions = evaluation[dep_name]
             if dep.valid:
                 fname = dep.feature_name
                 if self.filter_name is not None:
                     fname = fname + f", filtered by: {self.filter_name}"
                 fig, res = dependence.plot_partial_dependence_with_uncertainty(
                     dep.grid,
-                    dep.predictions,
+                    predictions,
                     fname,
                     density=dep.density,
                     categorical=dep.categorical,
@@ -350,7 +380,7 @@ class PartialDependanceEvaluator(Evaluator):
         return figs, ress
 
 
-class _Dependance():
+class _Dependance:
     """Simple tuple class to hold dependence parameters for PD evaluator."""
 
     def __init__(self, X, feature_name, grid_values="auto"):
@@ -371,7 +401,6 @@ class _Dependance():
         self.grid = grid
         self.density = density
         self.categorical = categorical
-        self.predictions = []
 
 
 class PermutationImportanceEvaluator(Evaluator):
@@ -468,7 +497,7 @@ class PermutationImportanceEvaluator(Evaluator):
         self.n_original_columns = X.shape[1]
         self.random_state = random_state
 
-    def evaluate(self, estimator, X, y):
+    def evaluate(self, estimator, X, y) -> List[np.ndarray]:
         """Evaluate the fitted estimator with input data.
 
         This is called by a model evaluation function in model_evaluation.
@@ -512,9 +541,13 @@ class PermutationImportanceEvaluator(Evaluator):
             grouped=self.grouped,
         )
 
-        self.imprt_samples.append(imprt.importances)
+        return [imprt.importances]
 
-    def get_results(self, ntop=10, name=None) -> mpl.figure.Figure:
+    def aggregate(self, evaluations: Sequence[List[np.ndarray]]) -> List[np.ndarray]:
+        """Concatenate sequence of evaluations."""
+        return _flatten(evaluations)
+
+    def get_results(self, evaluation, ntop=10, name=None) -> mpl.figure.Figure:
         """Get permutation importance plot.
 
         Parameters
@@ -529,7 +562,7 @@ class PermutationImportanceEvaluator(Evaluator):
         mpl.figure.Figure
             Permutation importance figure
         """
-        samples = np.hstack(self.imprt_samples)
+        samples = np.hstack(evaluation)
         name = name + " " if name is not None else ""
         title = f"{name}Permutation Importance"
         fig = _plot_importance(
@@ -636,3 +669,30 @@ def _np_or_pd_fill_col(X, column, fill_val):
     else:
         X[:, column] = fill_val
     return X
+
+
+# "key-value" type variables
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+def _flatten(list_of_lists: Sequence[List[V]]) -> List[V]:
+    """Flatten list of lists by concatenation."""
+    return functools.reduce(operator.add, list_of_lists)
+
+
+def _merge_dicts_of_lists_by_concatting(
+    dict1: Dict[K, List[V]], dict2: Dict[K, List[V]]
+) -> Dict[K, List[V]]:
+    """Merge two dicts where values are lists, by concatenating the values of duplicate keys.
+
+    Not commutative (as list concatenation is not commutative), but not lossy.
+
+    >>> _merge_dicts_of_lists_by_concatting({"k1": [1,2], "k2": [3]}, {"k1": [4], "k3": [5]})
+    {"k1": [1,2,4], "k2": [3], "k3": [5]}
+    """
+    merged_dict = {
+        k: dict1.get(k, default=[]) + dict2.get(k, default=[])
+        for k in dict1.keys() + dict2.keys()
+    }
+    return merged_dict

--- a/cinspect/model_evaluation.py
+++ b/cinspect/model_evaluation.py
@@ -33,7 +33,7 @@ def crossval_model(
     ] = None,  # defaults to KFold(n_splits=5)
     random_state: Optional[Union[int, np.random.RandomState]] = None,
     stratify: Optional[Union[np.ndarray, pd.Series]] = None,
-    n_jobs=-1,
+    n_jobs=1,
 ) -> Sequence[Evaluator]:
     """
     Evaluate a model using cross validation.
@@ -74,7 +74,7 @@ def bootstrap_model(
     replications: int = 100,
     random_state: Optional[Union[int, np.random.RandomState]] = None,
     use_group_cv: bool = False,
-    n_jobs=-1,
+    n_jobs=1,
 ) -> Sequence[Evaluator]:
     """
     Retrain a model using bootstrap re-sampling.
@@ -126,7 +126,7 @@ def bootcross_model(
     test_size: Union[int, float] = 0.25,
     random_state: Optional[Union[int, np.random.RandomState]] = None,
     use_group_cv: bool = False,
-    n_jobs=-1,
+    n_jobs=1,
 ) -> Sequence[Tuple[Evaluator, Any]]:
     """
     Use bootstrapping to compute random train/test folds (no sample sharing).
@@ -213,7 +213,7 @@ def _repeatedly_evaluate_model(
     evaluators: Sequence[Evaluator],
     use_group_cv: bool = False,
     random_state: Optional[Union[int, np.random.RandomState]] = None,
-    n_jobs=-1,
+    n_jobs=1,
     name_for_logging: str = "Evaluation",
 ) -> Sequence[Tuple[Evaluator, Any]]:
     # Runs code that requires the full set of data to be available For example

--- a/cinspect/model_evaluation.py
+++ b/cinspect/model_evaluation.py
@@ -7,7 +7,6 @@ import inspect
 import logging
 import time
 from functools import singledispatch
-from tabnanny import check
 from typing import Optional, Sequence, Tuple, Union
 
 import numpy as np

--- a/cinspect/model_evaluation.py
+++ b/cinspect/model_evaluation.py
@@ -98,7 +98,7 @@ def bootstrap_model(
     random_state = check_random_state(random_state)
 
     bootstrap_split_generator = (
-        # identical train, test sets TODO: should we be evaluating on the whole data set?
+        # identical train, test sets
         (split1 := resample(indices, random_state=random_state), split1)
         for _ in range(replications)
     )
@@ -305,7 +305,7 @@ def _train_model(
 ):
     group = _check_group_estimator(estimator, use_group_cv)
     X_train, y_train = _get_rows(X, train_indices), _get_rows(y, train_indices)
-    if group and "groups" in inspect.signature(estimator.fit).parameters.keys():
+    if group:
         estimator.fit(X_train, y_train, groups=train_indices)
     else:
         estimator.fit(X_train, y_train)

--- a/cinspect/model_evaluation.py
+++ b/cinspect/model_evaluation.py
@@ -3,19 +3,20 @@
 """Causal model evaluation functions."""
 
 
-import time
-import logging
 import inspect
-import numpy as np
-import pandas as pd
-
+import logging
+import time
 from functools import singledispatch
-from typing import Union, Optional, Sequence
-from sklearn.model_selection import KFold
-from sklearn.utils import resample, check_random_state
+from tabnanny import check
+from typing import Optional, Sequence, Tuple, Union
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
 from sklearn.base import BaseEstimator
-from sklearn.model_selection import BaseCrossValidator
+from sklearn.model_selection import BaseCrossValidator, KFold
 from sklearn.model_selection._search import BaseSearchCV
+from sklearn.utils import check_random_state, resample
 
 from cinspect.evaluators import Evaluator
 
@@ -27,7 +28,9 @@ def crossval_model(
     X: pd.DataFrame,
     y: Union[pd.Series, pd.DataFrame],
     evaluators: Sequence[Evaluator],
-    cv: Optional[Union[int, BaseCrossValidator]] = None,
+    cv: Optional[
+        Union[int, BaseCrossValidator]
+    ] = None,  # defaults to KFold(n_splits=5)
     random_state: Optional[Union[int, np.random.RandomState]] = None,
     stratify: Optional[Union[np.ndarray, pd.Series]] = None,
 ) -> Sequence[Evaluator]:
@@ -39,34 +42,23 @@ def crossval_model(
     """
     # Run various checks and prepare the evaluators
     random_state = check_random_state(random_state)
-    for ev in evaluators:
-        ev.prepare(estimator, X, y, random_state=random_state)
 
     cv = 5 if cv is None else cv
     if isinstance(cv, int):
         cv = KFold(n_splits=cv, shuffle=True, random_state=random_state)
 
-    LOG.info("Validating ...")
-
-    for i, (rind, sind) in enumerate(cv.split(X, stratify)):
-        LOG.info(f"Validation round {i + 1}")
-        start = time.time()
-
-        Xr, Xs = _split_data(X, rind, sind)
-        yr, ys = _split_data(y, rind, sind)
-        estimator.fit(Xr, yr)
-        for ev in evaluators:
-            ev.evaluate(estimator, Xs, ys)
-
-        end = time.time()
-        LOG.info(f"... iteration time {end - start:.2f}s")
-
-    LOG.info("Validation done.")
-
-    for ev in evaluators:
-        ev.aggregate()
-
-    return evaluators
+    cross_val_split_generator = cv.split(X, stratify)
+    eval_results = _repeatedly_evaluate_model(
+        estimator=estimator,
+        X=X,
+        y=y,
+        train_test_indices_generator=cross_val_split_generator,
+        evaluators=evaluators,
+        use_group_cv=False,
+        random_state=random_state,
+        name_for_logging="Bootstrap",
+    )
+    return eval_results
 
 
 def bootstrap_model(
@@ -76,7 +68,7 @@ def bootstrap_model(
     evaluators: Sequence[Evaluator],
     replications: int = 100,
     random_state: Optional[Union[int, np.random.RandomState]] = None,
-    use_group_cv: bool = False
+    use_group_cv: bool = False,
 ) -> Sequence[Evaluator]:
     """
     Retrain a model using bootstrap re-sampling.
@@ -98,26 +90,23 @@ def bootstrap_model(
     # Run various checks and prepare the evaluators
     indices = np.arange(len(X))
     random_state = check_random_state(random_state)
-    groups = _check_group_estimator(estimator, use_group_cv)
-    for ev in evaluators:
-        ev.prepare(estimator, X, y, random_state=random_state)
 
-    LOG.info("Bootstrapping ...")
-
-    # Bootstrapping loop
-    for i in range(replications):
-        LOG.info(f"Bootstrap round {i + 1}")
-        start = time.time()
-
-        Xb, yb, indb = resample(X, y, indices, random_state=random_state)
-        estimator.fit(Xb, yb, groups=indb) if groups else estimator.fit(Xb, yb)
-        for ev in evaluators:
-            ev.evaluate(estimator, Xb, yb)
-
-        end = time.time()
-        LOG.info(f"... iteration time {end - start:.2f}s")
-
-    LOG.info("Bootstrapping done.")
+    bootstrap_split_generator = (
+        # identical train, test sets TODO: should we be evaluating on the whole data set?
+        (split1 := resample(indices, random_state=random_state), split1)
+        for _ in range(replications)
+    )
+    eval_results = _repeatedly_evaluate_model(
+        estimator=estimator,
+        X=X,
+        y=y,
+        train_test_indices_generator=bootstrap_split_generator,
+        evaluators=evaluators,
+        use_group_cv=use_group_cv,
+        random_state=random_state,
+        name_for_logging="Bootstrap",
+    )
+    return eval_results
 
     for ev in evaluators:
         ev.aggregate()
@@ -133,7 +122,7 @@ def bootcross_model(
     replications: int = 100,
     test_size: Union[int, float] = 0.25,
     random_state: Optional[Union[int, np.random.RandomState]] = None,
-    use_group_cv: bool = False
+    use_group_cv: bool = False,
 ) -> Sequence[Evaluator]:
     """
     Use bootstrapping to compute random train/test folds (no sample sharing).
@@ -150,6 +139,7 @@ def bootcross_model(
         `GroupKFold`. This stops the same sample appearing in both the test and
         training splits of any inner cross validation.
     """
+    random_state = check_random_state(random_state)
     n = len(X)
     if isinstance(test_size, float):
         if test_size <= 0 or test_size >= 1:
@@ -159,35 +149,22 @@ def bootcross_model(
         if test_size <= 0 or test_size >= n:
             raise ValueError("test_size must be within the size of X")
 
-    # Run various checks and prepare the evaluators
-    random_state = check_random_state(random_state)
-    groups = _check_group_estimator(estimator, use_group_cv)
-    for ev in evaluators:
-        ev.prepare(estimator, X, y, random_state=random_state)
-
     LOG.info("Bootstrap crossing...")
+    bootcross_split_generator = (
+        _bootcross_split(n, test_size, random_state) for _ in range(replications)
+    )
+    eval_results = _repeatedly_evaluate_model(
+        estimator=estimator,
+        X=X,
+        y=y,
+        train_test_indices_generator=bootcross_split_generator,
+        evaluators=evaluators,
+        use_group_cv=use_group_cv,
+        random_state=random_state,
+        name_for_logging="Bootstrap-crossing",
+    )
 
-    # Bootstrapping loop
-    for i in range(replications):
-        LOG.info(f"Bootstrap cross round {i + 1}")
-        start = time.time()
-
-        tri, tsi = _bootcross_split(n, test_size, random_state)
-        Xr, Xs = _split_data(X, tri, tsi)
-        yr, ys = _split_data(y, tri, tsi)
-        estimator.fit(Xr, yr, groups=tri) if groups else estimator.fit(Xr, yr)
-        for ev in evaluators:
-            ev.evaluate(estimator, Xs, ys)
-
-        end = time.time()
-        LOG.info(f"... iteration time {end - start:.2f}s")
-
-    LOG.info("Bootstrapping crossing done.")
-
-    for ev in evaluators:
-        ev.aggregate()
-
-    return evaluators
+    return eval_results
 
 
 def _check_group_estimator(estimator, use_group_cv):
@@ -196,8 +173,9 @@ def _check_group_estimator(estimator, use_group_cv):
         spec = inspect.signature(estimator.fit)
         if "groups" not in spec.parameters:
             LOG.warning(
-                "`groups` parameter passed to bootstrap_model, but "
-                "estimator doesn't support groups. Fitting without groups."
+                "`use_group_cv` parameter passed to a `model_evaluation` procedure"
+                " (e.g. `bootstrap`), but estimator doesn't support groups."
+                " Fitting without groups."
             )
             return False
     elif isinstance(estimator, BaseSearchCV):
@@ -219,19 +197,132 @@ def _bootcross_split(data_size, test_size, random_state):
     return train_boot, test_boot
 
 
-@singledispatch
+# -- Bootstrapping/validation duplicate code --
+def _repeatedly_evaluate_model(
+    estimator: BaseEstimator,
+    X: pd.DataFrame,
+    y: Union[pd.DataFrame, pd.Series],
+    train_test_indices_generator: Sequence[
+        Tuple[npt.ArrayLike, npt.ArrayLike]  # train, test index arrays
+    ],
+    evaluators: Sequence[Evaluator],
+    use_group_cv: bool = False,
+    random_state: Optional[Union[int, np.random.RandomState]] = None,
+    name_for_logging: str = "Evaluation",
+):
+    # Runs code that requires the full set of data to be available For example
+    # to select the range over which partial dependence should be shown.
+
+    for ev in evaluators:
+        ev.prepare(estimator, X, y, random_state=random_state)
+
+    results_per_iteration = []
+    LOG.info(f"{name_for_logging}...")
+    for i, (r_ind, s_ind) in enumerate(train_test_indices_generator):
+        LOG.info(f"{name_for_logging} round {i + 1}")
+        start = time.time()
+
+        results = [
+            _train_evaluate_model(
+                estimator,
+                X,
+                y,
+                train_indices=r_ind,
+                test_indices=s_ind,
+                evaluator=ev,
+                use_group_cv=use_group_cv,
+            )
+            for ev in evaluators
+        ]
+        results_per_iteration.append(results)
+
+        end = time.time()
+        LOG.info(f"... iteration time {end - start:.2f}s")
+    # aggregate over iterations for each evaluator
+    results_combined = [
+        evaluators[j].aggregate(
+            [iter_results[j] for iter_results in results_per_iteration]
+        )
+        for j in range(len(evaluators))
+    ]
+    # breakpoint()
+    LOG.info(f"{name_for_logging} complete")
+
+    return list(zip(evaluators, results_combined))
+
+
+def _train_evaluate_model(
+    estimator, X, y, train_indices, test_indices, evaluator, use_group_cv=False
+):
+    est = _train_model(
+        estimator=estimator,
+        X=X,
+        y=y,
+        train_indices=train_indices,
+        use_group_cv=use_group_cv,
+    )
+    evl = _evaluate_model(
+        estimator=est,  # trained estimator
+        X=X,
+        y=y,
+        test_indices=test_indices,
+        evaluator=evaluator,
+    )
+    return evl
+
+
+def _train_model(
+    estimator: BaseEstimator,  # mutated, returned
+    X: pd.DataFrame,
+    y: Union[pd.DataFrame, pd.Series],
+    train_indices: Sequence[int],
+    use_group_cv: bool = False,
+):
+    group = _check_group_estimator(estimator, use_group_cv)
+    X_train, y_train = _get_rows(X, train_indices), _get_rows(y, train_indices)
+    if group and "groups" in inspect.signature(estimator.fit).parameters.keys():
+        estimator.fit(X_train, y_train, groups=train_indices)
+    else:
+        estimator.fit(X_train, y_train)
+    return estimator  # mutated input
+
+
+def _evaluate_model(
+    estimator: BaseEstimator,
+    X: pd.DataFrame,
+    y: Union[pd.DataFrame, pd.Series],
+    evaluator: Evaluator,
+    test_indices: Sequence[int]
+):
+    evaluation = evaluator.evaluate(
+        estimator, _get_rows(X, test_indices), _get_rows(y, test_indices)
+    )
+    # breakpoint()
+    return evaluation
+
+
+# --- Data-splitting helpers ---
+
+
 def _split_data(data, train_ind, test_ind):
+    data_r, data_s = _get_rows(data, train_ind), _get_rows(data, test_ind)
+    return data_r, data_s
+
+
+# Dynamically dispatched row-getters
+@singledispatch
+def _get_rows(data, indices):
     raise TypeError(f"Array type {type(data)} not recognised.")
 
 
-@_split_data.register(np.ndarray)
-def _(data, train_ind, test_ind):
-    data_r, data_s = data[train_ind], data[test_ind]
-    return data_r, data_s
+@_get_rows.register(np.ndarray)
+def _(data, indices):
+    rows = data[indices]
+    return rows
 
 
-@_split_data.register(pd.DataFrame)
-@_split_data.register(pd.Series)
-def _(data, train_ind, test_ind):
-    data_r, data_s = data.iloc[train_ind], data.iloc[test_ind]
-    return data_r, data_s
+@_get_rows.register(pd.Series)
+@_get_rows.register(pd.DataFrame)
+def _(data, indices):
+    rows = data.iloc[indices]
+    return rows

--- a/tests/test_evaluators.py
+++ b/tests/test_evaluators.py
@@ -81,9 +81,10 @@ def test_linear_binary_ate(
         )
 
         ate_est.prepare(estimator, X=XT_train, y=Y_train)
-        ate_est.evaluate(estimator, X=XT_test, y=Y_test)
-        ate = ate_est.ate_samples[0]
-        return ate
+
+        ate = ate_est.evaluate(estimator, X=XT_test, y=Y_test)
+
+        return ate[0]
 
     bootstrap_indices = test_utils.draw_bootstrap_samples(
         np.arange(n_test_samples),

--- a/tests/testing_strategies.py
+++ b/tests/testing_strategies.py
@@ -51,7 +51,7 @@ def Xy_np(
         n_rows_ = n_rows
 
     n_X_cols = draw(hst.integers(min_value=1, max_value=10))
-    n_y_cols = draw(hst.integers(min_value=1, max_value=10))
+    n_y_cols = draw(hst.integers(min_value=1, max_value=2))
 
     X_shape = (n_rows_, n_X_cols)
     y_shape = (n_rows_, n_y_cols)

--- a/tests/testing_strategies.py
+++ b/tests/testing_strategies.py
@@ -36,7 +36,7 @@ def Xy_np(
         Passed in by hst.composite decorator to construct a composite strategy
     n_rows : Optional[Union[int, hst.SearchStrategy[int]]], optional
         Number of data rows. If strategy, draw from it. If None, draw from default
-        strategy; integer between 1 and 30. By default None
+        strategy; integer between 1 and 10. By default None
 
     Returns
     -------
@@ -44,7 +44,7 @@ def Xy_np(
         Input, output test data
     """
     if n_rows is None:
-        n_rows_ = draw(hst.integers(min_value=1, max_value=30))
+        n_rows_ = draw(hst.integers(min_value=1, max_value=10))
     elif not isinstance(n_rows, int):
         n_rows_ = draw(n_rows)
     else:
@@ -92,14 +92,14 @@ def Xy_pd(
         Passed in by hst.composite decorator to construct a composite strategy
     n_rows : Optional[Union[int, hst.SearchStrategy[int]]], optional
         Number of data rows. If strategy, draw from it. If None, draw from default
-        strategy; integer between 1 and 30. By default None
+        strategy; integer between 1 and 10. By default None
 
     Returns
     -------
     (X, y) : Tuple[pd.DataFrame, pd.DataFrame]
         Input, output test data
     """
-    n_rows_ = hst.integers(min_value=1, max_value=30) if n_rows is None else n_rows
+    n_rows_ = hst.integers(min_value=1, max_value=10) if n_rows is None else n_rows
     X, y = draw(Xy_np(n_rows=n_rows_))
     X_pd = pd.DataFrame(X)
     y_pd = (


### PR DESCRIPTION
- Consolidate bootstrap/crossval/cross-fold logic
- Modify Evaluator; retains similar external interface, but makes aggregation and state modification explicit, separates these from `evaluate()`, to facilitate parallelism
- Adds parallel execution of model evaluation with `joblib`
- Add consistency tests for parallelism
- Starts to consolidate data generation code for `model_evaluation` hypothesis tests