### PR TITLE
Ignore Flake8 rule E203

### DIFF
--- a/cinspect/evaluators.py
+++ b/cinspect/evaluators.py
@@ -238,7 +238,7 @@ class PartialDependanceEvaluator(Evaluator):
             # we use the X, y information only to select the values over which
             # to compute dependence and to plot the density/counts for each
             # feature.
-            transformer = clone(estimator[0:self.end_transform_indx])
+            transformer = clone(estimator[0 : self.end_transform_indx])
             X = transformer.fit_transform(X, y)
 
         if self.conditional_filter is not None:
@@ -247,9 +247,7 @@ class PartialDependanceEvaluator(Evaluator):
         dep_params = {}
         if self.feature_grids is not None:
             for feature_name, grid_values in self.feature_grids.items():
-                dep_params[feature_name] = _Dependance(
-                    X, feature_name, grid_values
-                )
+                dep_params[feature_name] = _Dependance(X, feature_name, grid_values)
         else:
             for feature_name in X.columns:
                 dep_params[feature_name] = _Dependance(X, feature_name)
@@ -262,9 +260,9 @@ class PartialDependanceEvaluator(Evaluator):
         This is called by a model evaluation function in model_evaluation.
         """
         if self.end_transform_indx is not None:
-            transformer = estimator[0:self.end_transform_indx]
+            transformer = estimator[0 : self.end_transform_indx]
             Xt = transformer.transform(X)
-            predictor = estimator[self.end_transform_indx:]
+            predictor = estimator[self.end_transform_indx :]
 
         else:
             predictor = estimator
@@ -350,7 +348,7 @@ class PartialDependanceEvaluator(Evaluator):
         return figs, ress
 
 
-class _Dependance():
+class _Dependance:
     """Simple tuple class to hold dependence parameters for PD evaluator."""
 
     def __init__(self, X, feature_name, grid_values="auto"):
@@ -437,7 +435,7 @@ class PermutationImportanceEvaluator(Evaluator):
         This is called by a model evaluation function in model_evaluation.
         """
         if self.end_transform_indx is not None:
-            transformer = clone(estimator[0:self.end_transform_indx])
+            transformer = clone(estimator[0 : self.end_transform_indx])
             X = transformer.fit_transform(X, y)
 
         if self.grouped:
@@ -474,9 +472,9 @@ class PermutationImportanceEvaluator(Evaluator):
         This is called by a model evaluation function in model_evaluation.
         """
         if self.end_transform_indx is not None:
-            transformer = estimator[0:self.end_transform_indx]
+            transformer = estimator[0 : self.end_transform_indx]
             Xt = transformer.transform(X)
-            predictor = estimator[self.end_transform_indx:]
+            predictor = estimator[self.end_transform_indx :]
 
         else:
             predictor = estimator

--- a/cinspect/model_evaluation.py
+++ b/cinspect/model_evaluation.py
@@ -76,7 +76,7 @@ def bootstrap_model(
     evaluators: Sequence[Evaluator],
     replications: int = 100,
     random_state: Optional[Union[int, np.random.RandomState]] = None,
-    use_group_cv: bool = False
+    use_group_cv: bool = False,
 ) -> Sequence[Evaluator]:
     """
     Retrain a model using bootstrap re-sampling.
@@ -133,7 +133,7 @@ def bootcross_model(
     replications: int = 100,
     test_size: Union[int, float] = 0.25,
     random_state: Optional[Union[int, np.random.RandomState]] = None,
-    use_group_cv: bool = False
+    use_group_cv: bool = False,
 ) -> Sequence[Evaluator]:
     """
     Use bootstrapping to compute random train/test folds (no sample sharing).

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ convention = numpy
 
 [flake8]
 max-line-length = 100
+extend-ignore = E203
 inline-quotes = "
 exclude =
     # No need to traverse our git directory

--- a/simulations/simple_sim.py
+++ b/simulations/simple_sim.py
@@ -105,8 +105,9 @@ def main():
     # Casual estimation
     pdeval = PartialDependanceEvaluator(feature_grids={"T": "auto"})
     pieval = PermutationImportanceEvaluator(n_repeats=5)
-    bootcross_model(model, X, Y, [pdeval, pieval], replications=30,
-                    use_group_cv=True)  # To make sure we pass use GroupKFold
+    bootcross_model(
+        model, X, Y, [pdeval, pieval], replications=30, use_group_cv=True
+    )  # To make sure we pass use GroupKFold
 
     pdeval.get_results(mode="interval")
     pdeval.get_results(mode="derivative")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ def linear_causal_data():
     rnd = np.random.RandomState(42)
     z = rnd.normal(size=n)
     t = 0.2 * z + rnd.normal(scale=0.2, size=n)
-    y = alpha * t + beta * z + rnd.normal(scale=.1, size=n)
+    y = alpha * t + beta * z + rnd.normal(scale=0.1, size=n)
     X = np.vstack((t, z)).T
 
     return X, y, alpha

--- a/tests/test_model_evaluation.py
+++ b/tests/test_model_evaluation.py
@@ -9,8 +9,12 @@ import hypothesis.strategies as hst
 import numpy as np
 import pytest
 from cinspect.evaluators import Evaluator
-from cinspect.model_evaluation import (_bootcross_split, bootcross_model,
-                                       bootstrap_model, crossval_model)
+from cinspect.model_evaluation import (
+    _bootcross_split,
+    bootcross_model,
+    bootstrap_model,
+    crossval_model,
+)
 from hypothesis import given
 from numpy.random.mtrand import RandomState
 from sklearn.base import BaseEstimator
@@ -181,10 +185,11 @@ class _MockLinearEstimator(BaseEstimator):
 
 @test_utils.repeat_flaky_test(
     # replicate to reduce chance of false positive
-    n_repeats=10, n_allowed_failures=1
-    )
+    n_repeats=10,
+    n_allowed_failures=1,
+)
 def test_bootstrap_samples_from_eval_distribution(
-        make_simple_data, n_bootstraps=10, random_state=42
+    make_simple_data, n_bootstraps=10, random_state=42
 ):
     """Test that true mean is in 95%CI of bootstrap samples.
 
@@ -319,7 +324,7 @@ y_strategy = Xy_strategy_shared.map(lambda Xy: Xy[1])
 
 test_size_strategy = hst.one_of(
     hst.integers(min_value=1, max_value=n - 1),
-    hst.floats(min_value=1.0 / n, max_value=(n-1.0) / n),
+    hst.floats(min_value=1.0 / n, max_value=(n - 1.0) / n),
 )
 
 


### PR DESCRIPTION
Flake8 [enforces its rule E203 too strictly when it comes to slicing syntax](https://github.com/PyCQA/pycodestyle/issues/373).

This appears to violate [PEP8](https://peps.python.org/pep-0008/#pet-peeves).

Auto-linting tool `black`, for example, [contradicts E203 in favour of PEP8, and recommends disabling E203](https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8).

I often find myself manually removing spaces in slices to please `flake8` after running `black` over the code, and I'm not convinced that the resulting code is easier to read.

This PR simply disables E203 and runs `black` over the code. This is obviously a matter of taste/style, and is open to discussion

