### PR TITLE
Change return type for conditional correlation and covariance

### DIFF
--- a/cinspect/stats.py
+++ b/cinspect/stats.py
@@ -98,9 +98,9 @@ def conditional_corrcoef(X, Y, estimator=None):
 
 
 def _ndarray_to_df(ndarray, Y):
-    """ Turns an ndarray into a df with labels from Y"""
+    """Turn an ndarray into a df with labels from Y."""
     df = pd.DataFrame(ndarray)
-    if hasattr(Y, 'columns'):
+    if hasattr(Y, "columns"):
         columns = Y.columns
         df.columns = columns
         df.index = columns

--- a/cinspect/stats.py
+++ b/cinspect/stats.py
@@ -57,7 +57,7 @@ def conditional_cov(X, Y, estimator=None, bias=False, ddof=None):
     RY = Y - EY_X
     cov = np.cov(RY.T, bias=bias, ddof=ddof)  # equal E[(Y-E[Y|X])(Y-E[Y|X]).T]
 
-    if isinstance(Y, pd.DataFrame) and Y.shape[1] > 1:
+    if isinstance(Y, pd.DataFrame) and not np.ndim(cov) == 0:
         cov = _ndarray_to_df(cov, Y)
 
     return cov
@@ -91,7 +91,7 @@ def conditional_corrcoef(X, Y, estimator=None):
     var = np.diag(cov)
     corr = cov / np.sqrt(np.outer(var, var))
 
-    if isinstance(Y, pd.DataFrame) and Y.shape[1] > 1:
+    if isinstance(Y, pd.DataFrame) and not np.ndim(corr) == 0:
         corr = _ndarray_to_df(corr, Y)
 
     return corr

--- a/cinspect/stats.py
+++ b/cinspect/stats.py
@@ -57,7 +57,7 @@ def conditional_cov(X, Y, estimator=None, bias=False, ddof=None):
     RY = Y - EY_X
     cov = np.cov(RY.T, bias=bias, ddof=ddof)  # equal E[(Y-E[Y|X])(Y-E[Y|X]).T]
 
-    if isinstance(Y, pd.DataFrame):
+    if isinstance(Y, pd.DataFrame) and Y.shape[1] > 1:
         cov = _ndarray_to_df(cov, Y)
 
     return cov
@@ -91,7 +91,7 @@ def conditional_corrcoef(X, Y, estimator=None):
     var = np.diag(cov)
     corr = cov / np.sqrt(np.outer(var, var))
 
-    if isinstance(Y, pd.DataFrame):
+    if isinstance(Y, pd.DataFrame) and Y.shape[1] > 1:
         corr = _ndarray_to_df(corr, Y)
 
     return corr

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache 2.0 License.
 """Test the extra statistical functions."""
 import numpy as np
+import pandas as pd
 import pytest
 import test_utils
 from scipy.linalg import svd
@@ -54,6 +55,8 @@ def test_conditional_correlation_correctness(func, ccorr, corr):
     """Test the correctness of the conditional correlation computation."""
     X, Y = func()
     calc_ccorr = conditional_corrcoef(X, Y)
+    if (isinstance(calc_ccorr, pd.DataFrame)):
+        calc_ccorr = calc_ccorr.to_numpy()
     calc_corr = np.corrcoef(Y.T)
     assert np.allclose(np.diag(calc_corr), 1.)
     assert np.allclose(calc_ccorr[0, 1], ccorr, atol=0.05)
@@ -68,6 +71,8 @@ def test_inputs(ysize, xsize):
     X = np.random.randn(N, xsize)
 
     ccov = conditional_cov(X, Y)
+    if (isinstance(ccov, pd.DataFrame)):
+        ccov = ccov.to_numpy()
     if ysize > 1:
         assert ccov.shape == (ysize, ysize)
         _, s, _ = svd(ccov)


### PR DESCRIPTION
* Returns a DataFrame instead of a ndarray if input Y is a DataFrame
* Includes labels from Y