### PR TITLE
Flake8 fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,4 +40,4 @@ jobs:
 #          make typecheck      
       - name: Test
         run: |
-          make test
+          make test-ci

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ typecheck:
 	mypy ./cinspect
 
 lint:
-	py.test --flake8 ./cinspect -p no:regtest --cache-clear
+	flake8 ./cinspect
 
 isort:
 	isort .

--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,7 @@ isort:
 	isort .
 
 test:
-	pytest . --cov=cinspect tests/	
+	pytest . --cov=cinspect tests/
+
+test-ci:
+	pytest . --cov=cinspect tests/ --hypothesis-profile "ci"

--- a/cinspect/evaluators.py
+++ b/cinspect/evaluators.py
@@ -264,7 +264,6 @@ class PartialDependanceEvaluator(Evaluator):
         """Construct a PartialDependanceEvaluator."""
         self.feature_grids = feature_grids
         self.conditional_filter = conditional_filter
-        self.filter_name = filter_name
         self.end_transform_indx = end_transform_indx
 
     def prepare(self, estimator, X, y, random_state=None):
@@ -361,9 +360,10 @@ class PartialDependanceEvaluator(Evaluator):
             _description_, by default None
         ci_bounds: tuple, optional
             _description_, by default (0.025, 0.975)
-        name: str, optional
-            a name to prepend to the PD plot titles
-
+        tname: str, optional
+            a name to prepend to the feature names in PD plots
+        yname: str, optional
+            a name to #TODO document here and plot_partial_dependence_with_uncertainty
         Returns
         -------
         dict[str, mpl.figure.Figure]
@@ -383,8 +383,8 @@ class PartialDependanceEvaluator(Evaluator):
             predictions = evaluation[dep_name]
             if dep.valid:
                 fname = dep.feature_name
-                if name is not None:
-                    fname = name + " " + fname
+                if tname is not None:
+                    fname = tname + " " + fname
                 fig, res = dependence.plot_partial_dependence_with_uncertainty(
                     dep.grid,
                     predictions,

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ setup(
     extras_require={
         "dev": [
             "pytest",
-            "pytest-flake8",
             "pytest-mock",
             "flake8-bugbear",
             "flake8-builtins",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,18 @@
 # Copyright (c) Gradient Institute. All rights reserved.
 # Licensed under the Apache 2.0 License.
 """Test fixtures."""
-
+import os
 import numpy as np
 import pandas as pd
 import pytest
+from hypothesis import settings, Verbosity
+
+
+# register test flags for hypothesis; allows e.g. extended deadlines on CI
+settings.register_profile("ci", deadline=milliseconds(1000))
+settings.register_profile("dev", max_examples=10)
+settings.register_profile("debug", max_examples=10, verbosity=Verbosity.verbose)
+settings.load_profile(os.getenv(u"HYPOTHESIS_PROFILE", "default"))
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache 2.0 License.
 """Test fixtures."""
 import os
+from datetime import timedelta
 import numpy as np
 import pandas as pd
 import pytest
@@ -9,7 +10,7 @@ from hypothesis import settings, Verbosity
 
 
 # register test flags for hypothesis; allows e.g. extended deadlines on CI
-settings.register_profile("ci", deadline=milliseconds(1000))
+settings.register_profile("ci", deadline=timedelta(milliseconds=1000))
 settings.register_profile("dev", max_examples=10)
 settings.register_profile("debug", max_examples=10, verbosity=Verbosity.verbose)
 settings.load_profile(os.getenv(u"HYPOTHESIS_PROFILE", "default"))


### PR DESCRIPTION
In the process of working on #43, it became apparent that the immediate issue with the current linting setup (in Make/CI) was that flake8 was being run via pytest, which is easily solved. 

This pull request just runs flake8 directly, and I've addressed the linting errors that were raised by this as best I can.

If this is the extent of the issue with flake8, we can close #43. Otherwise, we can choose an alternative (see discussion on #43)