### PR TITLE
Quick CI fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     keywords="causality inspection interpretability",
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=["cinspect"],
+    packages=["cinspect", "simulations"],
     # List run-time dependencies here.  These will be installed by pip when
     # your project is installed. For an analysis of "install_requires" vs pip"s
     # requirements files see:


### PR DESCRIPTION
The easiest way I found to fix the CI was to export the `simulations` package explicitly in `setup.py`.

I'm not sure why this wasn't failing in previous iterations, in hindsight.

Additionally, I'm not entirely certain that this is the desired structure - the simulations are useful, but maybe they should be named as a sub-package (e.g. `cinspect.simulations`), rather than a completely separate one? This is probably a matter of taste/convention, and I'm not sure that I'm the person to make that judgement

This addresses #55 